### PR TITLE
[OOTDay-6] 회원가입 기능

### DIFF
--- a/src/main/java/TOTs/OOTDay/config/PasswordEncoderConfig.java
+++ b/src/main/java/TOTs/OOTDay/config/PasswordEncoderConfig.java
@@ -5,7 +5,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-//
 @Configuration
 public class PasswordEncoderConfig {
 

--- a/src/main/java/TOTs/OOTDay/controller/MemberController.java
+++ b/src/main/java/TOTs/OOTDay/controller/MemberController.java
@@ -2,8 +2,6 @@ package TOTs.OOTDay.controller;
 
 
 import TOTs.OOTDay.dto.MemberJoinDTO;
-import TOTs.OOTDay.dto.NameValidationRequest;
-import TOTs.OOTDay.dto.PhoneValidationRequest;
 import TOTs.OOTDay.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -25,18 +23,5 @@ public class MemberController {
     public ResponseEntity<UUID> join(@RequestBody MemberJoinDTO joinDTO) {
         UUID id = memberService.join(joinDTO); // 회원가입 후 UUID 받아옴.
         return ResponseEntity.ok(id);
-    }
-
-    // 이름 유효성 검사
-    @PostMapping("/validate-name")
-    public ResponseEntity<String> validateName(@RequestBody NameValidationRequest request) {
-        memberService.validateName(request.getName());
-        return ResponseEntity.ok("가능한 이름입니다.");
-    }
-
-    @PostMapping("/validate-phone")
-    public ResponseEntity<String> validatePhone(@RequestBody PhoneValidationRequest request) {
-        memberService.validatePhoneNumber(request.getPhoneNumber());
-        return ResponseEntity.ok("가능한 번호입니다.");
     }
 }

--- a/src/main/java/TOTs/OOTDay/dto/IdValidationRequest.java
+++ b/src/main/java/TOTs/OOTDay/dto/IdValidationRequest.java
@@ -1,0 +1,11 @@
+package TOTs.OOTDay.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+// Id 입력
+@Getter
+@Setter
+public class IdValidationRequest {
+    private String memberId;
+}

--- a/src/main/java/TOTs/OOTDay/dto/MemberJoinDTO.java
+++ b/src/main/java/TOTs/OOTDay/dto/MemberJoinDTO.java
@@ -10,8 +10,11 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class MemberJoinDTO {
+    private String name; // 이름
+    private String phoneNumber; // 전화번호
     private String memberId; // 아이디
     private String password; // 비밀번호
-    private String phoneNumber; // 전화번호
+    private String confirmPassword; // 비밀번호 재확인
     private MemberEntity.Gender gender; // 성별 -> MALE/FEMALE
+    private boolean agree; //약관 동의 여부
 }

--- a/src/main/java/TOTs/OOTDay/entity/MemberEntity.java
+++ b/src/main/java/TOTs/OOTDay/entity/MemberEntity.java
@@ -18,13 +18,19 @@ public class MemberEntity {
     @Id // 기본키
     @GeneratedValue
     @Column(name = "id", columnDefinition = "uuid") // UUID
-    private UUID id;
+    private UUID id; // UUID
+
+    @Column(nullable = false)
+    private String name; // 이름
 
     @Column(name = "member_id", nullable = false, unique = true)
     private String memberId; // 아이디
 
     @Column(nullable = false)
     private String password; // 비밀번호
+
+    @Column(name = "agree")
+    private boolean agree; // 약관 동의 여부
 
     /*
     @Column(length = 255)


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) 6

## 📝작업 내용
> 회원가입 기능

이름 조건 : 한글, 영어만 사용 가능, 숫자, 띄어쓰기, 특수문자 불가, 2 - 5
전화 번호 조건 : 82+ 1012345678 형식으로 숫자만 가능
아이디 조건 : 영어, 숫자 조합(5 ~10자)
비밀번호 조건 : 영어와 숫자 특수 문자 조합으로(8 ~ 10자)
비밀번호 조건에 맞다면 재확인 받기.
이용약관 true인지

구현 중이라 ddl-auto: create로 진행

-조건에 다 충족한 경우
<img width="567" height="383" alt="image" src="https://github.com/user-attachments/assets/b2fc4b5b-e0e8-4f98-b54f-4587b2251993" />

-조건에 충족하지 않은 경우
<img width="567" height="383" alt="image" src="https://github.com/user-attachments/assets/c7f0c2e8-16fe-442d-9aee-d5eae8a3a8b7" />
 --> DB에 저장 X

-아이디가 다른 사용자와 일치하는 경우
<img width="567" height="348" alt="image" src="https://github.com/user-attachments/assets/af2a7ebc-e491-4657-a770-257a2a62f3cf" />

-아이디는 다른 사람과 같을 수 X
-하지만, 비밀번호는 다른 사람과 같은 경우? -> BCrypt 사용해서 비밀번호 해시값이 다르게 처리했습니다.

## 💬리뷰 요구사항
> 
1. 전 PR 때 말하신 1번 참고해서 1개의 API로 받을 수 있게 수 있게 수정했습니다.
2. 이름, 아이디, 비밀번호 글자 수 좀 변경할까 하다가 일단은 안했습니다.

