### PR TITLE
[OOTDay-25] S3 이미지 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,13 +41,19 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
 	//implementation 'org.springframework.ai:spring-ai-starter-model-stability-ai'
 
-//jwt 의존성 0.11.5 버전
+	//jwt 의존성 0.11.5 버전
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'commons-codec:commons-codec:1.15'
 
 	//비밀번호 암호화하기 위해서
 	implementation 'org.springframework.security:spring-security-crypto'
+
+	//s3
+	implementation 'software.amazon.awssdk:s3:2.20.136'
+
+
 }
 
 dependencyManagement {

--- a/src/main/java/TOTs/OOTDay/util/s3/S3Config.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3Config.java
@@ -1,0 +1,30 @@
+package TOTs.OOTDay.util.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/TOTs/OOTDay/util/s3/S3Controller.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3Controller.java
@@ -1,0 +1,36 @@
+package TOTs.OOTDay.util.s3;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3ServiceImpl s3Service;
+    /**
+     * 범용 S3 업로드 엔드포인트
+     *
+     * @param file 업로드할 파일
+     * @param domain 업로드 도메인 (enum name)
+     * @param uuid 연관된 엔티티 UUID
+     */
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadFile(
+            @RequestParam MultipartFile file,
+            @RequestParam("domain") S3DomainType domain,
+            @RequestParam("uuid") UUID uuid) throws IOException {
+
+        String url = s3Service.uploadFile(file, domain, uuid);
+        return ResponseEntity.ok(url);
+    }
+}

--- a/src/main/java/TOTs/OOTDay/util/s3/S3DomainType.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3DomainType.java
@@ -1,0 +1,20 @@
+package TOTs.OOTDay.util.s3;
+
+import lombok.Getter;
+
+/**
+ * S3에 업로드되는 파일들의 도메인 구분을 위한 Enum이 구성된 파일입니다.
+ * 각 항목은 고유한 prefix 경로를 가짐.
+ */
+@Getter
+public enum S3DomainType {
+    FEED("feed/"),
+    CLOTHES("user/clothes/"),
+    STYLING("user/styling/");
+
+    private final String prefix;
+
+    S3DomainType(String prefix) {
+        this.prefix = prefix;
+    }
+}

--- a/src/main/java/TOTs/OOTDay/util/s3/S3KeyGenerator.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3KeyGenerator.java
@@ -1,0 +1,50 @@
+package TOTs.OOTDay.util.s3;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * S3 Key 생성 유틸리티 클래스
+ *
+ * - 도메인별 prefix 생성
+ * - 파일 해시 기반 S3 Key 생성
+ */
+public class S3KeyGenerator {
+
+    /**
+     * 파일 명을 노출시키지 않기위해 SHA-256 해시 기반으로 S3 Key(파일명)으로 생성 (확장자 자동 추출)
+     *
+     * @param file MultipartFile
+     * @param domainType 도메인 구분 Enum
+     * @param folderUuid 폴더 구분용 UUID
+     * @return 예: feed/{UUID}/{SHA-256}.{ext}
+     * @throws IOException
+     */
+    public static String generateFileKeyWithHash(MultipartFile file, S3DomainType domainType, UUID folderUuid) throws IOException {
+        String prefix = generatePrefix(domainType, folderUuid);
+        String extension = getExtension(Objects.requireNonNull(file.getOriginalFilename()));
+        String fileHash = DigestUtils.sha256Hex(file.getInputStream());
+        return prefix + fileHash + extension;
+    }
+
+    /**
+     * 도메인 유형과 UUID를 조합하여 S3 prefix 생성
+     *
+     * @param domainType 도메인 구분 Enum
+     * @param folderUuid 폴더 구분용 UUID
+     * @return 예: feed/{UUID}/
+     */
+    public static String generatePrefix(S3DomainType domainType, UUID folderUuid) {
+        return domainType.getPrefix() + folderUuid + "/";
+    }
+
+    //파일의 마지막 .를 추출하여 확장자 추출하기
+    private static String getExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf(".");
+        return dotIndex != -1 ? fileName.substring(dotIndex) : "";
+    }
+}

--- a/src/main/java/TOTs/OOTDay/util/s3/S3KeyGenerator.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3KeyGenerator.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 
 /**
  * S3 Key 생성 유틸리티 클래스
- *
  * - 도메인별 prefix 생성
  * - 파일 해시 기반 S3 Key 생성
  */

--- a/src/main/java/TOTs/OOTDay/util/s3/S3Service.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3Service.java
@@ -3,6 +3,7 @@ package TOTs.OOTDay.util.s3;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 public interface S3Service  {
@@ -12,7 +13,7 @@ public interface S3Service  {
      * @param file   업로드할 파일 (MultipartFile)
      * @param domainType 도메인 타입
      * @param folderUuid 폴더 식별용 UUID
-     * @return 업로드된 파일의 CloudFront URL (예: https://cdn.example.com/profiles/{UUID}/abc123.png)
+     * @return 업로드된 파일의 CloudFront URL (예: https://cdn.example.com/feed/{UUID}/abc123.png)
      * @throws IOException 파일 읽기/업로드 중 오류 발생 시
      */
     String uploadFile(MultipartFile file, S3DomainType domainType, UUID folderUuid) throws IOException;
@@ -31,4 +32,13 @@ public interface S3Service  {
      * @param key 삭제할 객체의 Key
      */
     void deleteFile(String key);
+
+    /**
+     * 특정 폴더(prefix) 내의 모든 파일을 삭제합니다.
+     *
+     * @param prefix 삭제할 폴더의 prefix
+     */
+    void deleteFolder(String prefix);
+
+    List<String> listKeys(String prefix);
 }

--- a/src/main/java/TOTs/OOTDay/util/s3/S3Service.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3Service.java
@@ -1,0 +1,34 @@
+package TOTs.OOTDay.util.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+public interface S3Service  {
+    /**
+     * S3에 파일을 업로드하고, 업로드된 파일의 CloudFront URL을 반환합니다.
+     *
+     * @param file   업로드할 파일 (MultipartFile)
+     * @param domainType 도메인 타입
+     * @param folderUuid 폴더 식별용 UUID
+     * @return 업로드된 파일의 CloudFront URL (예: https://cdn.example.com/profiles/{UUID}/abc123.png)
+     * @throws IOException 파일 읽기/업로드 중 오류 발생 시
+     */
+    String uploadFile(MultipartFile file, S3DomainType domainType, UUID folderUuid) throws IOException;
+
+    /**
+     * 지정한 S3 Key의 객체 존재 여부를 확인합니다.
+     *
+     * @param key S3 객체의 Key
+     * @return 객체가 존재하면 true, 없으면 false
+     */
+    boolean doesObjectExist(String key);
+
+    /**
+     * S3에서 파일을 삭제합니다.
+     *
+     * @param key 삭제할 객체의 Key
+     */
+    void deleteFile(String key);
+}

--- a/src/main/java/TOTs/OOTDay/util/s3/S3ServiceImpl.java
+++ b/src/main/java/TOTs/OOTDay/util/s3/S3ServiceImpl.java
@@ -1,0 +1,94 @@
+package TOTs.OOTDay.util.s3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3ServiceImpl implements S3Service{
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.cloudfront.url}")
+    private String cloudFrontUrl;
+
+    /**
+     * S3에 파일 업로드 (파일명은 SHA-256 해시 기반으로 생성)
+     *
+     * @param file 업로드할 파일
+     * @param domainType 도메인 타입
+     * @param folderUuid 폴더 식별용 UUID
+     * @return 업로드된 파일의 CloudFront URL
+     * @throws IOException
+     */
+
+    @Override
+    public String uploadFile(MultipartFile file, S3DomainType domainType, UUID folderUuid) throws IOException {
+        String fileUrl = S3KeyGenerator.generateFileKeyWithHash(file, domainType, folderUuid);
+
+        log.info("[S3 업로드 요청] key: {}", fileUrl);
+
+
+        // 이미 존재하는지 확인
+        if (!doesObjectExist(fileUrl)) {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileUrl)
+                    .contentType(file.getContentType())
+                    .build();
+            s3Client.putObject(request, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+            log.info("[S3 업로드 완료] key: {}", fileUrl);
+        } else {
+            log.info("[S3에 동일한 파일 존재. 업로드 생략] key: {}", fileUrl);
+        }
+
+        return cloudFrontUrl + "/" + fileUrl;
+    }
+
+    @Override
+    public boolean doesObjectExist(String key) {
+        try {
+            HeadObjectRequest headRequest = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+            s3Client.headObject(headRequest);
+            return true;
+        } catch (S3Exception e) {
+            return false;
+        }
+    }
+
+    @Override
+    public void deleteFile(String key) {
+        log.info("[S3 삭제 요청] key: {}", key);
+
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        try {
+            s3Client.deleteObject(deleteRequest);
+            log.info("[S3 삭제 완료] key: {}", key);
+        } catch (S3Exception e) {
+            log.error("[S3 삭제 실패] key: {}, message: {}", key, e.awsErrorDetails().errorMessage());
+            throw e;
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #25 

## 📝작업 내용
S3 이미지 업로드 및 삭제 기능을 범용 유틸 형태로 구현한것입니다. 각 도메인별 비지니스 로직은 서비스 레이어에서 이 유틸을 사용해 처리해주세요.

- S3에 이미지 파일을 업로드하고 CloudFront URL로 반환
- 파일명은 동일한 파일의 중복 업로드 방지를 위해 SHA-256 해시 기반으로 생성됩니다.
- 폴더 UUID 기반 저장 구조 적용
- S3 단일 파일 및 폴더 단위 삭제 기능 추가

## 💬리뷰 요구사항
