### PR TITLE
[OOTDay-43] 인증/인가 구현

### DIFF
--- a/src/main/java/TOTs/OOTDay/config/JwtAuthInterceptor.java
+++ b/src/main/java/TOTs/OOTDay/config/JwtAuthInterceptor.java
@@ -1,0 +1,44 @@
+package TOTs.OOTDay.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class JwtAuthInterceptor implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String uri = request.getRequestURI();
+
+        System.out.println("요청 URI: " + uri);
+
+        // 인증 X 허용(로그인, 회원가입, 아이디/비밀번호 찾기, sms 관련 모든 것)
+        if (uri.startsWith("/api/members/login") ||
+                uri.startsWith("/api/members/join") ||
+                uri.startsWith("/api/members/find-id") ||
+                uri.startsWith("/api/members/reset-password") ||
+                uri.startsWith("/sms/")) {
+            return true;
+        }
+
+        // Authorization 헤더 확인
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json; charset=UTF-8");
+            response.getWriter().write("{\"message\": \"로그인 후에 사용하실 수 있습니다.\"}");
+            return false;
+        }
+        String token = authHeader.substring(7);
+
+        // JWT 유효성 검사
+        try {
+            JwtUtil.getMemberIdFromToken(token);
+        } catch (Exception e) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json; charset=UTF-8");
+            response.getWriter().write("{\"message\": \"로그인 후에 사용하실 수 있습니다.\"}");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/TOTs/OOTDay/config/WebConfig.java
+++ b/src/main/java/TOTs/OOTDay/config/WebConfig.java
@@ -1,0 +1,22 @@
+package TOTs.OOTDay.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new JwtAuthInterceptor())
+                .addPathPatterns("/**") // 모든 url에 적용
+                .excludePathPatterns(
+                        "/api/members/login", // 로그인
+                        "/api/members/join", // 회원가입
+                        "/api/members/find-id", // 아이디 찾기
+                        "/api/members/reset-password/**", // 비밀번호 찾기
+                        "/sms/**", // sms 관련 모든 것
+                        "/error"
+                );
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #43 

## 📝작업 내용
> 로그인, 회원가입, 아이디 찾기, 비밀번호 찾기, 메시지(휴대폰 인증)은 로그인 없어도 접근 가능

>그 외 모든 것 로그인(JWT 토큰 없이는 불가)하게 구현

--> 설문은 로그인 후에 사용 가능(인가)

>로그인 후 설문
<img width="567" height="335" alt="image" src="https://github.com/user-attachments/assets/4b3402f6-fef7-432f-971e-502074e505fe" />
--> 정보 저장

> 로그인 X 설문 시
<img width="567" height="360" alt="image" src="https://github.com/user-attachments/assets/6021666a-e9ca-492c-a97f-a80dc55164a7" />
<img width="386" height="43" alt="image" src="https://github.com/user-attachments/assets/1efc841f-4732-4e25-97ed-78d961ff522d" />
--> 에러 발생(JSON 형식으로 반환)


## 💬리뷰 요구사항
> 
